### PR TITLE
More meaningful message when Slack returns error

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -89,7 +89,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         var profile = JSON.parse(body);
 
         if (!profile.ok) {
-          done(profile);
+          done(body);
         } else {
           delete profile.ok;
 


### PR DESCRIPTION
`done` callback expects text, that's why we cant pass JSON obj there