### PR TITLE
Include the access token in the header instead of querystring

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -49,7 +49,7 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
   options.scope = options.scope || ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team'];
 
-  this.profileUrl = options.profileUrl || "https://slack.com/api/users.identity?token="; // requires 'identity.basic' scope
+  this.profileUrl = options.profileUrl || "https://slack.com/api/users.identity"; // requires 'identity.basic' scope
   this._team = options.team;
 
   OAuth2Strategy.call(this, options, verify);
@@ -81,7 +81,10 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  this.get(this.profileUrl + accessToken, function (err, body, res) {
+  var header = {
+    Authorization: 'Bearer ' + accessToken
+  };
+  this.get(this.profileUrl, header, function (err, body, res) {
     if (err) {
       return done(err);
     } else {
@@ -109,8 +112,8 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 /** The default oauth2 strategy puts the access_token into Authorization: header AND query string
  * which is a violation of the RFC so lets override and not add the header and supply only the token for qs.
  */
-Strategy.prototype.get = function(url, callback) {
-  this._oauth2._request("GET", url, {}, "", "", callback );
+Strategy.prototype.get = function(url, header, callback) {
+  this._oauth2._request("GET", url, header, "", "", callback );
 };
 
 


### PR DESCRIPTION
Fix #5 