### PR TITLE
Silence warning when using a different profileUrl

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -49,7 +49,8 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
   options.scope = options.scope || ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team'];
 
-  this.profileUrl = options.profileURL || options.profileUrl || "https://slack.com/api/users.identity"; // requires 'identity.basic' scope
+  var defaultProfileUrl =  "https://slack.com/api/users.identity" // requires 'identity.basic' scope
+  this.profileUrl = options.profileURL || options.profileUrl || defaultProfileUrl;
   this._team = options.team;
 
   OAuth2Strategy.call(this, options, verify);
@@ -57,7 +58,7 @@ function Strategy(options, verify) {
 
   // warn is not enough scope
   // Details on Slack's identity scope - https://api.slack.com/methods/users.identity
-  if(!this._skipUserProfile && this._scope.indexOf('identity.basic') === -1){
+  if(!this._skipUserProfile && this.profileUrl === defaultProfileUrl && this._scope.indexOf('identity.basic') === -1){
     console.warn("Scope 'identity.basic' is required to retrieve Slack user profile");
   }
 }


### PR DESCRIPTION
The URL `https://slack.com/api/auth.test` can be used as an alternative `profileURL` when using scopes other than the `identity.*` ones. In this case, the `identity.basic` scope is not required, but configuring this Strategy like this will causes a superfluous warning message to show up:

```
Scope 'identity.basic' is required to retrieve Slack user profile
```

Also, Slack does not allow `identity.*` scopes to be combined with ther scope types, such as `channels:write`, `channels:read`, etc. Therefore, without this change there is way to silence that warning log.