### PR TITLE
Adding user_scope in `authorizationParams`

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -51,6 +51,7 @@ function Strategy(options, verify) {
 
   this.profileUrl = options.profileURL || options.profileUrl || "https://slack.com/api/users.identity"; // requires 'identity.basic' scope
   this._team = options.team;
+  this._user_scope = options.user_scope;
 
   OAuth2Strategy.call(this, options, verify);
   this.name = options.name || 'Slack';
@@ -127,10 +128,18 @@ Strategy.prototype.get = function(url, header, callback) {
  */
 Strategy.prototype.authorizationParams = function (options) {
   var params = {};
+
   var team = options.team || this._team;
   if (team) {
     params.team = team;
   }
+
+  var user_scope = options.user_scope || this._user_scope;
+  if (user_scope) {
+    if (Array.isArray(user_scope)) { user_scope = user_scope.join(this._scopeSeparator); }
+    params.user_scope = user_scope;
+  }
+
   return params;
 };
 


### PR DESCRIPTION
Slack's OAuth2 implementation expects bot token scopes at "scope" and user token scopes at "user_scope". Please let me know if there's anything else you'd like me to do before this can be merged. 

https://api.slack.com/authentication/oauth-v2#asking

There is another module that has enabled this, but I'd prefer to make this change in the most popular passport strategy. 

https://www.npmjs.com/package/@workablehr/passport-slack-v2