### PR TITLE
Monkey Patch _oauth2.getOAuthAccessToken to reformat Slack's OAuth2 v2 token response

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install passport-slack-oauth2
 ## Sample Profile
 ```json
 {
-    "provider": "Slack",
+    "provider": "slack",
     "id": "U123XXXXX",
     "displayName": "John Agan",
     "user": {
@@ -28,6 +28,7 @@ $ npm install passport-slack-oauth2
         "image_72": "https://secure.gravatar.com/avatar/123abcd123bc12b3c.jpg?s=72&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0000-72.png",
         "image_192": "https://secure.gravatar.com/avatar/123abcd123bc12b3c.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0000-192.png",
         "image_512": "https://secure.gravatar.com/avatar/123abcd123bc12b3c.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0000-512.png"
+        "image_1024": "https://secure.gravatar.com/avatar/123abcd123bc12b3c.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0000-1024.png"
     },
     "team": {
         "id": "T123XXXX",
@@ -43,7 +44,6 @@ $ npm install passport-slack-oauth2
         "image_default": true
     }
 }
-
 ```
 
 ## Usage
@@ -60,13 +60,97 @@ passport.use(new SlackStrategy({
     clientID: CLIENT_ID,
     clientSecret: CLIENT_SECRET,
     skipUserProfile: false, // default
-    scope: ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team'] // default
+    scope: ['users:read'] // default, bot token scope
+    scope: ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team'] // default, user token scope
   },
   (accessToken, refreshToken, profile, done) => {
     // optionally persist user data into a database
     done(null, profile);
   }
 ));
+```
+
+In order to access multiple tokens within the OAuth2 Token Response, provide a verify callback with 5 parameters.
+
+```js
+passport.use(new SlackStrategy({
+    clientID: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    skipUserProfile: false, // default
+    scope: ['users:read'] // bot token scope, default
+    scope: ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team'] // user token scope, default
+  },
+  (accessToken, refreshToken, params, profile, done) => { // 5 parameters
+    // optionally persist user data into a database
+    done(null, profile);
+  }
+));
+```
+
+## Sample Parsed Token Responses
+
+### User & Bot
+```json
+{
+    "id": "U123XXXXX",
+    "scope": "user-scope-1,user-scope-2",
+    "token_type": "user",
+    "access_token": "user-access-token",
+    "refresh_token": "user-refresh-token",
+    "authed_user": {
+        "id": "U123XXXXX",
+        "scope": "user-scope-1,user-scope-2",
+        "access_token": "user-access-token",
+        "token_type": "user"
+    },
+    "authed_bot": {
+        "id": "U987XXXXX",
+        "scope": "bot-scope-1,bot-scope-2",
+        "token_type": "bot",
+        "access_token": "bot-access-token",
+        "refresh_token": "bot-refresh-token"
+    }
+}
+```
+
+### User only
+```json
+{
+    "id": "U123XXXXX",
+    "scope": "user-scope-1,user-scope-2",
+    "token_type": "user",
+    "access_token": "user-access-token",
+    "refresh_token": "user-refresh-token",
+    "authed_user": {
+        "id": "U123XXXXX",
+        "scope": "user-scope-1,user-scope-2",
+        "access_token": "user-access-token",
+        "token_type": "user"
+    },
+    "authed_bot": {
+    }
+}
+```
+
+### Bot only
+```json
+{
+    "id": "U987XXXXX",
+    "scope": "bot-scope-1,bot-scope-2",
+    "token_type": "bot",
+    "access_token": "bot-access-token",
+    "refresh_token": "bot-refresh-token",
+    "authed_user": {
+        "id": "U123XXXXX",
+    },
+    "authed_bot": {
+        "id": "U987XXXXX",
+        "scope": "bot-scope-1,bot-scope-2",
+        "token_type": "bot",
+        "access_token": "bot-access-token",
+        "refresh_token": "bot-refresh-token",
+    }
+}
 ```
 
 ### Authenticate Requests
@@ -78,22 +162,41 @@ For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
 ```js
-app.get('/auth/slack', passport.authorize('Slack'));
+app.get('/auth/slack', passport.authorize('slack'));
 
 app.get('/auth/slack/callback',
-  passport.authenticate('Slack', { failureRedirect: '/login' }),
+  passport.authenticate('slack', { failureRedirect: '/login' }),
   (req, res) => res.redirect('/') // Successful authentication, redirect home.
 );
 ```
 
-### Custom Scopes
-By default passport-slack strategy will try to retrieve [all user identity](https://api.slack.com/methods/users.identity) from Slack using the default scopes of `identity.basic`, `identity.email`, `identity.avatar`, and `identity.team`. To override these, set the `scope` parameter to an array of scopes.
+### Custom User Scopes
+By default passport-slack strategy will try to retrieve [all user identity](https://api.slack.com/methods/users.identity) from Slack using the default scopes of `identity.basic`, `identity.email`, `identity.avatar`, and `identity.team`. To override these, set the `user_scope` parameter to an array of [user scopes](https://api.slack.com/scopes?filter=user).
 
 ```js
 passport.use(new SlackStrategy({
-	clientID: CLIENT_ID,
-	clientSecret: CLIENT_SECRET,
-	scope: ['identity.basic', 'channels:read', 'chat:write:user']
+  clientID: CLIENT_ID,
+  clientSecret: CLIENT_SECRET,
+  scope: [],                      // no (bot) 'scope' defined, no bot tokens issued
+  user_scope: [
+    "identity.basic",
+    "channels:read",
+    "chat:write:user"
+  ]
+}, () => { });
+```
+
+### Custom Bot Scopes
+By default passport-slack strategy will try to retrieve [bot info](https://api.slack.com/methods/users.info) from Slack using the default scopes of `users:read`. To override these, set the `scope` parameter to an array of [bot scopes](https://api.slack.com/scopes?filter=granular_bot).
+
+```js
+passport.use(new SlackStrategy({
+  clientID: CLIENT_ID,
+  clientSecret: CLIENT_SECRET,
+  scope: [
+    "users:read"
+  ],
+  user_scope: []                  // no 'user_scope' defined, no user tokens issued
 }, () => { });
 ```
 
@@ -104,6 +207,7 @@ passport.use(new SlackStrategy({
 	clientID: CLIENT_ID,
 	clientSecret: CLIENT_SECRET,
 	scope: ['incoming-webhook'],
+	user_scope: ['incoming-webhook'],
 	skipUserProfile: true
 }, () => { });
 ```

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -152,7 +152,7 @@ Strategy.prototype.get = function(url, header, callback) {
  */
 
 Strategy.prototype.getOAuthAccessTokenAndHandleResponse = function (code, params, callback) {
-  const handleOAuthAccessTokenResponse = (function handleOAuthAccessTokenResponse (err, accessToken, refreshToken, params) {
+  const handleOAuthAccessTokenResponse = function (err, accessToken, refreshToken, params) {
     if (err) { return callback(err) }
 
     try {
@@ -198,9 +198,9 @@ Strategy.prototype.getOAuthAccessTokenAndHandleResponse = function (code, params
     } catch (ex) {
       return callback(ex);
     }
-  }).bind(this)
+  }
 
-  this._oauth2._getOAuthAccessToken(code, params, handleOAuthAccessTokenResponse);
+  this._oauth2._getOAuthAccessToken(code, params, handleOAuthAccessTokenResponse.bind(this));
 }
 
 /**

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -68,7 +68,7 @@ function Strategy(options, verify) {
       !~options.user_scope.indexOf('identity.basic') &&
       !~options.scope.indexOf('users:read') ){
 
-    console.error("Scope 'users:read' or UserScope 'identity.basic' is required to retrieve Slack profile");
+    console.warn("Scope 'users:read' or UserScope 'identity.basic' is required to retrieve Slack profile");
   }
 
   OAuth2Strategy.call(this, options, verify);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -4,6 +4,7 @@
 var util = require('util')
   , OAuth2Strategy = require('passport-oauth2').Strategy;
 
+var providerName = 'slack';
 
 /**
  * `Strategy` constructor.
@@ -20,7 +21,7 @@ var util = require('util')
  *   - `clientID`               your Slack application's client id
  *   - `clientSecret`           your Slack application's client secret
  *   - `callbackURL`            URL to which Slack will redirect the user after granting authorization
- *   - `scope`                  array of permission scopes to request defaults to:
+ *   - `scope`                  array of permission scopes to request bot access
  *                              ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team']
  *                              full set of scopes: https://api.slack.com/docs/oauth-scopes
  *
@@ -45,23 +46,32 @@ var util = require('util')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.tokenURL = options.tokenURL || 'https://slack.com/api/oauth.access';
-  options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
-  options.scope = options.scope || ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team'];
+  options.clientID = options.clientID || options.clientId;
+  options.tokenURL = options.tokenURL || options.tokenUrl || 'https://slack.com/api/oauth.v2.access';
+  options.authorizationURL = options.authorizationURL || options.authorizationUrl || 'https://slack.com/oauth/v2/authorize';
 
-  var defaultProfileUrl =  "https://slack.com/api/users.identity" // requires 'identity.basic' scope
+  // bot scope
+  options.scope = options.scope || ['users:read'];
+  // user scope
+  options.user_scope = options.user_scope || ['identity.basic', 'identity.email', 'identity.team', 'identity.avatar'];
+
+  this._team = options.team || options.teamId;
+
+  var defaultProfileUrl = 'https://slack.com/api/users.identity';
   this.profileUrl = options.profileURL || options.profileUrl || defaultProfileUrl;
-  this._team = options.team;
-  this._user_scope = options.user_scope;
+
+  //'https://slack.com/api/auth.test'          // info about the owner of a token
+  //'https://slack.com/api/users.info'         // info about a user
+  //'https://slack.com/api/bots.info?bot=1234' // info about a bot
 
   OAuth2Strategy.call(this, options, verify);
-  this.name = options.name || 'Slack';
+  this.name = options.name || providerName;
 
   // warn is not enough scope
   // Details on Slack's identity scope - https://api.slack.com/methods/users.identity
-  if(!this._skipUserProfile && this.profileUrl === defaultProfileUrl && this._scope.indexOf('identity.basic') === -1){
-    console.warn("Scope 'identity.basic' is required to retrieve Slack user profile");
-  }
+  //if(!this._skipUserProfile && this.profileUrl === defaultProfileUrl && this._scope.indexOf('identity.basic') === -1){
+    //console.warn("Scope 'identity.basic' is required to retrieve Slack user profile");
+  //}
 }
 
 /**
@@ -86,6 +96,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
   var header = {
     Authorization: 'Bearer ' + accessToken
   };
+
   this.get(this.profileUrl, header, function (err, body, res) {
     if (err) {
       return done(err);
@@ -98,7 +109,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         } else {
           delete profile.ok;
 
-          profile.provider = 'Slack';
+          profile.provider = providerName;
           profile.id = profile.user.id;
           profile.displayName = profile.user.name;
 
@@ -116,6 +127,62 @@ Strategy.prototype.userProfile = function(accessToken, done) {
  */
 Strategy.prototype.get = function(url, header, callback) {
   this._oauth2._request("GET", url, header, "", "", callback );
+};
+
+/**
+ * Passport's goal is User Authentication.
+ * Slack's OAuth2 v2 implementation supports simultaneous bot & user
+ * authentication. Slack's OAuth2 v2 token response can return multiple tokens
+ * within a single response. OAuth2 does not support issues multiple tokens
+ * as a set or array of responses. Therefore, in order for Slack to achieve
+ * multiple token responses, the user token response is nested inside of the
+ * bot token response.
+ * In order to align with Passport's User Authentication Goal, Slack's
+ * OAuth2 v2 token response needs to be reformatted to life the user token
+ * and nest the bot token. See https://github.com/nmaves/passport-slack-oauth2/issues/9#issuecomment-1544231819
+ *
+ * @param {String:null} accessToken
+ * @param {String:null} refreshToken
+ * @param {Object} params
+ * @return {Object}
+ */
+Strategy.prototype.handleOAuthAccessTokenResponse = function (accessToken, refreshToken, params, next) {
+  try {
+
+    // deep copy
+    var tokenResponse = JSON.parse(JSON.stringify(params));
+    delete tokenResponse.bot_user_id;
+    tokenResponse.authed_bot = {};
+
+    if (params.token_type === 'bot') {
+      // copy bot profile & tokens to authed_bot
+      tokenResponse.authed_bot.id = params.bot_user_id;
+      tokenResponse.authed_bot.scope = params.scope;
+      tokenResponse.authed_bot.token_type = params.token_type;
+      tokenResponse.authed_bot.access_token = params.access_token;
+      tokenResponse.authed_bot.refresh_token = params.refresh_token;
+    }
+
+    if (params.authed_user.token_type === 'user') {
+      // copy the authed_user tokens
+      accessToken = params.authed_user.access_token;
+      refreshToken = params.authed_user.refresh_token;
+
+      // copy the authed_user profile & tokens to root
+      tokenResponse.id = params.authed_user.id;
+      tokenResponse.scope = params.authed_user.scope;
+      tokenResponse.token_type = params.authed_user.token_type;
+      tokenResponse.access_token = params.authed_user.access_token;
+      tokenResponse.refresh_token = params.authed_user.refresh_token;
+    } else {
+      // normalize id
+      tokenResponse.id = params.bot_user_id;
+    }
+
+    next(null, accessToken, refreshToken, tokenResponse);
+  } catch (ex) {
+    return next(ex);
+  }
 };
 
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -55,23 +55,24 @@ function Strategy(options, verify) {
   // user scope
   options.user_scope = options.user_scope || ['identity.basic', 'identity.email', 'identity.team', 'identity.avatar'];
 
+  if ((!options.scope || options.scope.length == 0) && (!options.user_scope || options.user_scope.length == 0)) {
+    throw new TypeError('SlackStrategy requires at least one scope or user_scope');
+  }
+
   this._team = options.team || options.teamId;
 
-  var defaultProfileUrl = 'https://slack.com/api/users.identity';
-  this.profileUrl = options.profileURL || options.profileUrl || defaultProfileUrl;
+  this.profileUrl = options.profileURL || options.profileUrl;
+  this._hasCustomProfileUrl = !!this.profileUrl;
 
-  //'https://slack.com/api/auth.test'          // info about the owner of a token
-  //'https://slack.com/api/users.info'         // info about a user
-  //'https://slack.com/api/bots.info?bot=1234' // info about a bot
+  if( !this._skipUserProfile &&
+      !~options.user_scope.indexOf('identity.basic') &&
+      !~options.scope.indexOf('users:read') ){
+
+    console.error("Scope 'users:read' or UserScope 'identity.basic' is required to retrieve Slack profile");
+  }
 
   OAuth2Strategy.call(this, options, verify);
   this.name = options.name || providerName;
-
-  // warn is not enough scope
-  // Details on Slack's identity scope - https://api.slack.com/methods/users.identity
-  //if(!this._skipUserProfile && this.profileUrl === defaultProfileUrl && this._scope.indexOf('identity.basic') === -1){
-    //console.warn("Scope 'identity.basic' is required to retrieve Slack user profile");
-  //}
 }
 
 /**
@@ -148,7 +149,6 @@ Strategy.prototype.get = function(url, header, callback) {
  */
 Strategy.prototype.handleOAuthAccessTokenResponse = function (accessToken, refreshToken, params, next) {
   try {
-
     // deep copy
     var tokenResponse = JSON.parse(JSON.stringify(params));
     delete tokenResponse.bot_user_id;
@@ -161,6 +161,10 @@ Strategy.prototype.handleOAuthAccessTokenResponse = function (accessToken, refre
       tokenResponse.authed_bot.token_type = params.token_type;
       tokenResponse.authed_bot.access_token = params.access_token;
       tokenResponse.authed_bot.refresh_token = params.refresh_token;
+
+      if (!(this._skipUserProfile || this._hasCustomProfileUrl)) {
+        this.profileUrl = 'https://slack.com/api/users.info?user=' + params.bot_user_id;
+      }
     }
 
     if (params.authed_user.token_type === 'user') {
@@ -174,6 +178,10 @@ Strategy.prototype.handleOAuthAccessTokenResponse = function (accessToken, refre
       tokenResponse.token_type = params.authed_user.token_type;
       tokenResponse.access_token = params.authed_user.access_token;
       tokenResponse.refresh_token = params.authed_user.refresh_token;
+
+      if (!this._skipUserProfile || !this._hasCustomProfileUrl) {
+        this.profileUrl = 'https://slack.com/api/users.identity';
+      }
     } else {
       // normalize id
       tokenResponse.id = params.bot_user_id;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -47,6 +47,7 @@ var providerName = 'slack';
 function Strategy(options, verify) {
   options = options || {};
   options.clientID = options.clientID || options.clientId;
+  options.callbackURL = options.callbackURL || options.callbackUrl;
   options.tokenURL = options.tokenURL || options.tokenUrl || 'https://slack.com/api/oauth.v2.access';
   options.authorizationURL = options.authorizationURL || options.authorizationUrl || 'https://slack.com/oauth/v2/authorize';
 
@@ -59,7 +60,9 @@ function Strategy(options, verify) {
     throw new TypeError('SlackStrategy requires at least one scope or user_scope');
   }
 
-  this._team = options.team || options.teamId;
+  this._user_scope = options.user_scope;
+
+  this._team = options.team || options.teamId || options.teamID;
 
   this.profileUrl = options.profileURL || options.profileUrl;
   this._hasCustomProfileUrl = !!this.profileUrl;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -169,8 +169,10 @@ Strategy.prototype.getOAuthAccessTokenAndHandleResponse = function (code, params
         tokenResponse.authed_bot.id = params.bot_user_id;
         tokenResponse.authed_bot.scope = params.scope;
         tokenResponse.authed_bot.token_type = params.token_type;
-        tokenResponse.authed_bot.access_token = params.access_token;
-        tokenResponse.authed_bot.refresh_token = params.refresh_token;
+        tokenResponse.authed_bot.expires_in = params.expires_in;
+        tokenResponse.authed_bot.access_token = accessToken;
+        tokenResponse.authed_bot.refresh_token = refreshToken;
+        tokenResponse.refresh_token = refreshToken;
 
         if (!(this._skipUserProfile || this._hasCustomProfileUrl)) {
           this.profileUrl = 'https://slack.com/api/users.info?user=' + params.bot_user_id;
@@ -188,6 +190,7 @@ Strategy.prototype.getOAuthAccessTokenAndHandleResponse = function (code, params
         tokenResponse.token_type = params.authed_user.token_type;
         tokenResponse.access_token = params.authed_user.access_token;
         tokenResponse.refresh_token = params.authed_user.refresh_token;
+        tokenResponse.expires_in = params.authed_user.expires_in;
 
         if (!this._skipUserProfile || !this._hasCustomProfileUrl) {
           this.profileUrl = 'https://slack.com/api/users.identity';

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -73,6 +73,9 @@ function Strategy(options, verify) {
 
   OAuth2Strategy.call(this, options, verify);
   this.name = options.name || providerName;
+
+  this._oauth2._getOAuthAccessToken = this._oauth2.getOAuthAccessToken;
+  this._oauth2.getOAuthAccessToken = this.getOAuthAccessTokenAndHandleResponse.bind(this);
 }
 
 /**
@@ -134,66 +137,71 @@ Strategy.prototype.get = function(url, header, callback) {
  * Passport's goal is User Authentication.
  * Slack's OAuth2 v2 implementation supports simultaneous bot & user
  * authentication. Slack's OAuth2 v2 token response can return multiple tokens
- * within a single response. OAuth2 does not support issues multiple tokens
+ * within a single response. OAuth2 does not support tokens issued
  * as a set or array of responses. Therefore, in order for Slack to achieve
  * multiple token responses, the user token response is nested inside of the
  * bot token response.
- * In order to align with Passport's User Authentication Goal, Slack's
- * OAuth2 v2 token response needs to be reformatted to life the user token
- * and nest the bot token. See https://github.com/nmaves/passport-slack-oauth2/issues/9#issuecomment-1544231819
+ * Since Passport's goal is User Authentication, Slack's OAuth2 v2 token
+ * response needs to be reformatted to lift the user token and nest the bot token.
+ * See https://github.com/nmaves/passport-slack-oauth2/issues/9#issuecomment-1544231819
  *
  * @param {String:null} accessToken
  * @param {String:null} refreshToken
  * @param {Object} params
  * @return {Object}
  */
-Strategy.prototype.handleOAuthAccessTokenResponse = function (accessToken, refreshToken, params, next) {
-  try {
-    // deep copy
-    var tokenResponse = JSON.parse(JSON.stringify(params));
-    delete tokenResponse.bot_user_id;
-    tokenResponse.authed_bot = {};
 
-    if (params.token_type === 'bot') {
-      // copy bot profile & tokens to authed_bot
-      tokenResponse.authed_bot.id = params.bot_user_id;
-      tokenResponse.authed_bot.scope = params.scope;
-      tokenResponse.authed_bot.token_type = params.token_type;
-      tokenResponse.authed_bot.access_token = params.access_token;
-      tokenResponse.authed_bot.refresh_token = params.refresh_token;
+Strategy.prototype.getOAuthAccessTokenAndHandleResponse = function (code, params, callback) {
+  const handleOAuthAccessTokenResponse = (function handleOAuthAccessTokenResponse (err, accessToken, refreshToken, params) {
+    if (err) { return callback(err) }
 
-      if (!(this._skipUserProfile || this._hasCustomProfileUrl)) {
-        this.profileUrl = 'https://slack.com/api/users.info?user=' + params.bot_user_id;
+    try {
+      // deep copy
+      var tokenResponse = JSON.parse(JSON.stringify(params));
+      delete tokenResponse.bot_user_id;
+      tokenResponse.authed_bot = {};
+
+      if (params.token_type === 'bot') {
+        // copy bot profile & tokens to authed_bot
+        tokenResponse.authed_bot.id = params.bot_user_id;
+        tokenResponse.authed_bot.scope = params.scope;
+        tokenResponse.authed_bot.token_type = params.token_type;
+        tokenResponse.authed_bot.access_token = params.access_token;
+        tokenResponse.authed_bot.refresh_token = params.refresh_token;
+
+        if (!(this._skipUserProfile || this._hasCustomProfileUrl)) {
+          this.profileUrl = 'https://slack.com/api/users.info?user=' + params.bot_user_id;
+        }
       }
-    }
 
-    if (params.authed_user.token_type === 'user') {
-      // copy the authed_user tokens
-      accessToken = params.authed_user.access_token;
-      refreshToken = params.authed_user.refresh_token;
+      if (params.authed_user.token_type === 'user') {
+        // copy the authed_user tokens
+        accessToken = params.authed_user.access_token;
+        refreshToken = params.authed_user.refresh_token;
 
-      // copy the authed_user profile & tokens to root
-      tokenResponse.id = params.authed_user.id;
-      tokenResponse.scope = params.authed_user.scope;
-      tokenResponse.token_type = params.authed_user.token_type;
-      tokenResponse.access_token = params.authed_user.access_token;
-      tokenResponse.refresh_token = params.authed_user.refresh_token;
+        // copy the authed_user profile & tokens to root
+        tokenResponse.id = params.authed_user.id;
+        tokenResponse.scope = params.authed_user.scope;
+        tokenResponse.token_type = params.authed_user.token_type;
+        tokenResponse.access_token = params.authed_user.access_token;
+        tokenResponse.refresh_token = params.authed_user.refresh_token;
 
-      if (!this._skipUserProfile || !this._hasCustomProfileUrl) {
-        this.profileUrl = 'https://slack.com/api/users.identity';
+        if (!this._skipUserProfile || !this._hasCustomProfileUrl) {
+          this.profileUrl = 'https://slack.com/api/users.identity';
+        }
+      } else {
+        // normalize id
+        tokenResponse.id = params.bot_user_id;
       }
-    } else {
-      // normalize id
-      tokenResponse.id = params.bot_user_id;
+
+      callback(null, accessToken, refreshToken, tokenResponse);
+    } catch (ex) {
+      return callback(ex);
     }
+  }).bind(this)
 
-    next(null, accessToken, refreshToken, tokenResponse);
-  } catch (ex) {
-    return next(ex);
-  }
-};
-
-
+  this._oauth2._getOAuthAccessToken(code, params, handleOAuthAccessTokenResponse);
+}
 
 /**
  * Return extra Slack parameters to be included in the authorization
@@ -218,8 +226,6 @@ Strategy.prototype.authorizationParams = function (options) {
 
   return params;
 };
-
-
 
 /**
  * Expose `Strategy`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "passport-slack-oauth2",
       "version": "1.2.0-next.0",
       "dependencies": {
-        "passport-oauth2": "file:../passport-oauth2"
+        "passport-oauth2": "^1.7.0"
       },
       "devDependencies": {
         "chai": "^4.3.7",
@@ -17,6 +17,7 @@
     },
     "../passport-oauth2": {
       "version": "1.7.0",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "base64url": "3.x.x",
@@ -106,6 +107,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -721,6 +730,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -761,8 +775,31 @@
       }
     },
     "node_modules/passport-oauth2": {
-      "resolved": "../passport-oauth2",
-      "link": true
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.7.0.tgz",
+      "integrity": "sha512-j2gf34szdTF2Onw3+76alNnaAExlUmHvkc7cL+cmaS5NzHzDP/BvFHJruueQ9XAeNOdpI+CH+PWid8RA7KCwAQ==",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -934,6 +971,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/workerpool": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,32 +8,29 @@
       "name": "passport-slack-oauth2",
       "version": "1.2.0-next.0",
       "dependencies": {
-        "passport-oauth2": "^1.7.0"
+        "passport-oauth2": "file:../passport-oauth2"
+      },
+      "devDependencies": {
+        "chai": "^4.3.7",
+        "mocha": "^10.2.0"
       }
     },
-    "node_modules/base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
-    },
-    "node_modules/passport-oauth2": {
+    "../passport-oauth2": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.7.0.tgz",
-      "integrity": "sha512-j2gf34szdTF2Onw3+76alNnaAExlUmHvkc7cL+cmaS5NzHzDP/BvFHJruueQ9XAeNOdpI+CH+PWid8RA7KCwAQ==",
+      "license": "MIT",
       "dependencies": {
         "base64url": "3.x.x",
         "oauth": "0.9.x",
         "passport-strategy": "1.x.x",
         "uid2": "0.0.x",
         "utils-merge": "1.x.x"
+      },
+      "devDependencies": {
+        "chai": "2.x.x",
+        "chai-passport-strategy": "1.x.x",
+        "make-node": "0.4.6",
+        "mocha": "2.x.x",
+        "proxyquire": "0.6.x"
       },
       "engines": {
         "node": ">= 0.4.0"
@@ -43,25 +40,992 @@
         "url": "https://github.com/sponsors/jaredhanson"
       }
     },
-    "node_modules/passport-strategy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ=",
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
       "engines": {
-        "node": ">= 0.4.0"
+        "node": ">=6"
       }
     },
-    "node_modules/uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
-        "node": ">= 0.4.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "resolved": "../passport-oauth2",
+      "link": true
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "./lib/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",
@@ -33,6 +33,10 @@
   },
   "homepage": "https://github.com/nmaves/passport-slack-oauth2#readme",
   "dependencies": {
-    "passport-oauth2": "^1.7.0"
+    "passport-oauth2": "file:../passport-oauth2"
+  },
+  "devDependencies": {
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/nmaves/passport-slack-oauth2#readme",
   "dependencies": {
-    "passport-oauth2": "file:../passport-oauth2"
+    "passport-oauth2": "^1.7.0"
   },
   "devDependencies": {
     "chai": "^4.3.7",

--- a/test/strategy.handleOAuthAccessTokenReponse.test.js
+++ b/test/strategy.handleOAuthAccessTokenReponse.test.js
@@ -61,6 +61,7 @@ describe('handleOAuthAccessTokenReponse', function () {
         actual.accessToken = _accessToken;
         actual.refreshToken = _refreshToken;
         actual.params = _params;
+
         done();
       });
     });

--- a/test/strategy.handleOAuthAccessTokenReponse.test.js
+++ b/test/strategy.handleOAuthAccessTokenReponse.test.js
@@ -1,0 +1,398 @@
+const { expect } = require('chai');
+
+const Strategy = require('../lib').Strategy;
+
+describe('handleOAuthAccessTokenReponse', function () {
+  var options = {
+    clientId: 'clientId',
+    clientSecret: 'clientSecret',
+    callbackUrl: '/cb',
+  };
+
+  var strategy
+    , accessToken
+    , refreshToken
+    , params
+    , actual;
+
+  beforeEach(function() {
+    actual = {};
+    strategy = null;
+    accessToken = null;
+    refreshToken = null;
+    params = { /* define me in test */ };
+  });
+
+  context('on exception', function () {
+    beforeEach(function(done) {
+      strategy = new Strategy(options, () => {});
+
+      strategy.handleOAuthAccessTokenResponse('at', 'rt', function () { /* force an error */}, function (err) {
+        actual.error = err;
+        done();
+      });
+    });
+
+    it('passes an error into the callback on exception', function () {
+      expect(actual.error).to.exist;
+    });
+  });
+
+  context('pass thru params', function () {
+    let property, value;
+    beforeEach(function(done) {
+      strategy = new Strategy(options, () => {});
+
+      params = {
+        ok: true,
+        app_id: 'app-id',
+        authed_user: { id: 'user-id' },
+        team: { id: 'team-id', name: 'team-name' },
+        enterprise: null,
+        is_enterprise_install: false
+      };
+
+      property = Date.now();
+      value = Date.now();
+      params[property] = value;
+
+      strategy.handleOAuthAccessTokenResponse(accessToken, refreshToken, params, function (err, _accessToken, _refreshToken, _params) {
+        actual.error = err;
+        actual.accessToken = _accessToken;
+        actual.refreshToken = _refreshToken;
+        actual.params = _params;
+        done();
+      });
+    });
+
+    context('root object', function () {
+      it('passes through the ok property', function () {
+        expect(actual.params.ok).to.be.true;
+      });
+
+      it('passes through the app_id property', function () {
+        expect(actual.params.app_id).to.eql('app-id');
+      });
+
+      it('passes through the enterprise property', function () {
+        expect(actual.params.enterprise).to.be.null;
+      });
+
+      it('passes through the is_enterprise_install property', function () {
+        expect(actual.params.is_enterprise_install).to.be.false;
+      });
+
+      it('passes through a random property', function () {
+        expect(actual.params[property]).to.eql(value);
+      });
+
+      context('team property', function () {
+        it('passes through the team property', function () {
+          expect(actual.params.team).to.be.an('object');
+        });
+
+        it('passes through the team id property', function () {
+          expect(actual.params.team.id).to.eql('team-id');
+        });
+
+        it('passes through the team name property', function () {
+          expect(actual.params.team.name).to.eql('team-name');
+        });
+      });
+    });
+  });
+
+  context('user auth', function () {
+    beforeEach(function(done) {
+      strategy = new Strategy(options, () => {});
+
+      params = {
+        authed_user: {
+          id: 'user-id',
+          scope: 'user-scope-1,user-scope-2',
+          access_token: 'user-access-token',
+          token_type: 'user'
+        }
+      };
+
+      strategy.handleOAuthAccessTokenResponse(accessToken, refreshToken, params, function (err, _accessToken, _refreshToken, _params) {
+        actual.error = err;
+        actual.accessToken = _accessToken;
+        actual.refresToken = _refreshToken;
+        actual.params = _params;
+        done();
+      });
+    });
+
+    context('error', function () {
+      it('does not return an error', function () {
+        expect(actual.error).to.be.null;
+      });
+    });
+
+    context('tokens', function () {
+      it('returns the correct accessToken', function () {
+        expect(actual.accessToken).to.eql('user-access-token');
+      });
+
+      it('returns the correct refreshToken', function () {
+        expect(actual.refreshToken).to.not.exist;
+      });
+    });
+
+    context('root object', function () {
+      it('sets the user id as a root property', function () {
+        expect(actual.params.id).to.eql('user-id');
+      });
+
+      it('sets the user scope as a root property', function () {
+        expect(actual.params.scope).to.eql('user-scope-1,user-scope-2');
+      });
+
+      it('sets the user tokentype as a root property', function () {
+        expect(actual.params.token_type).to.eql('user');
+      });
+
+      it('sets the user access_token as a root property', function () {
+        expect(actual.params.access_token).to.eql('user-access-token');
+      });
+
+      it('sets the user refresh_token as a root property', function () {
+        expect(actual.params.refresh_token).to.not.exist;
+      });
+    });
+
+    context('authed_user', function () {
+      it('sets the user id on the authed_user property', function () {
+        expect(actual.params.authed_user.id).to.eql('user-id');
+      });
+
+      it('sets the user scope on the authed_user property', function () {
+        expect(actual.params.authed_user.scope).to.eql('user-scope-1,user-scope-2');
+      });
+
+      it('sets the user tokentype on the authed_user property', function () {
+        expect(actual.params.authed_user.token_type).to.eql('user');
+      });
+
+      it('sets the user access_token on the authed_user property', function () {
+        expect(actual.params.authed_user.access_token).to.eql('user-access-token');
+      });
+
+      it('sets the user refresh_token on the authed_user property', function () {
+        expect(actual.params.authed_user.refresh_token).to.not.exist;
+      });
+    });
+
+    context('authed_bot', function () {
+      it('sets an empty object for authed_bot', function () {
+        expect(actual.params.authed_bot).to.be.an('object').that.is.empty;
+      });
+    });
+  });
+
+  context('user and bot auth', function (done) {
+    beforeEach(function(done) {
+      strategy = new Strategy(options, () => {});
+
+      params = {
+        authed_user: {
+          id: 'user-id',
+          scope: 'user-scope-1,user-scope-2',
+          access_token: 'user-access-token',
+          token_type: 'user'
+        },
+        bot_user_id: 'bot-user-id',
+        scope: 'bot-scope-1,bot-scope-2',
+        access_token: 'bot-token',
+        token_type: 'bot',
+      };
+
+      accessToken = 'bot-token';
+
+      strategy.handleOAuthAccessTokenResponse(accessToken, refreshToken, params, function (err, _accessToken, _refreshToken, _params) {
+        actual.error = err;
+        actual.accessToken = _accessToken;
+        actual.refresToken = _refreshToken;
+        actual.params = _params;
+        done();
+      });
+    });
+
+    context('error', function () {
+      it('does not return an error', function () {
+        expect(actual.error).to.be.null;
+      });
+    });
+
+    context('tokens', function () {
+      it('returns the correct accessToken', function () {
+        expect(actual.accessToken).to.eql('user-access-token');
+      });
+
+      it('returns the correct refreshToken', function () {
+        expect(actual.refreshToken).to.not.exist;
+      });
+    });
+
+    context('root object', function () {
+      it('sets the user id as a root property', function () {
+        expect(actual.params.id).to.eql('user-id');
+      });
+
+      it('sets the user scope as a root property', function () {
+        expect(actual.params.scope).to.eql('user-scope-1,user-scope-2');
+      });
+
+      it('sets the user tokentype as a root property', function () {
+        expect(actual.params.token_type).to.eql('user');
+      });
+
+      it('sets the user access_token as a root property', function () {
+        expect(actual.params.access_token).to.eql('user-access-token');
+      });
+
+      it('sets the user refresh_token as a root property', function () {
+        expect(actual.params.refresh_token).to.not.exist;
+      });
+    });
+
+    context('authed_user', function () {
+      it('sets the user id on the authed_user property', function () {
+        expect(actual.params.authed_user.id).to.eql('user-id');
+      });
+
+      it('sets the user scope on the authed_user property', function () {
+        expect(actual.params.authed_user.scope).to.eql('user-scope-1,user-scope-2');
+      });
+
+      it('sets the user tokentype on the authed_user property', function () {
+        expect(actual.params.authed_user.token_type).to.eql('user');
+      });
+
+      it('sets the user access_token on the authed_user property', function () {
+        expect(actual.params.authed_user.access_token).to.eql('user-access-token');
+      });
+
+      it('sets the user refresh_token on the authed_user property', function () {
+        expect(actual.params.authed_user.refresh_token).to.not.exist;
+      });
+    });
+
+    context('authed_bot', function () {
+      it('sets the bot id on the authed_bot property', function () {
+        expect(actual.params.authed_bot.id).to.eql('bot-user-id');
+      });
+
+      it('sets the bot scope on the authed_bot property', function () {
+        expect(actual.params.authed_bot.scope).to.eql('bot-scope-1,bot-scope-2');
+      });
+
+      it('sets the bot tokentype on the authed_bot property', function () {
+        expect(actual.params.authed_bot.token_type).to.eql('bot');
+      });
+
+      it('sets the bot access_token on the authed_bot property', function () {
+        expect(actual.params.authed_bot.access_token).to.eql('bot-token');
+      });
+
+      it('sets the bot refresh_token on the authed_bot property', function () {
+        expect(actual.params.authed_bot.refresh_token).to.not.exist;
+      });
+    });
+  });
+
+  context('bot auth', function () {
+    beforeEach(function(done) {
+      strategy = new Strategy(options, () => {});
+
+      params = {
+        authed_user: { id: 'user-id' },
+        bot_user_id: 'bot-user-id',
+        scope: 'bot-scope-1,bot-scope-2',
+        access_token: 'bot-token',
+        token_type: 'bot',
+      };
+
+      accessToken = 'bot-token';
+
+      strategy.handleOAuthAccessTokenResponse(accessToken, refreshToken, params, function (err, _accessToken, _refreshToken, _params) {
+        actual.error = err;
+        actual.accessToken = _accessToken;
+        actual.refresToken = _refreshToken;
+        actual.params = _params;
+        done();
+      });
+    });
+
+    context('error', function () {
+      it('does not return an error', function () {
+        expect(actual.error).to.be.null;
+      });
+    });
+
+    context('tokens', function () {
+      it('returns the correct accessToken', function () {
+        expect(actual.accessToken).to.eql('bot-token');
+      });
+
+      it('returns the correct refreshToken', function () {
+        expect(actual.refreshToken).to.not.exist;
+      });
+    });
+
+    context('root object', function () {
+      it('sets the bot id as a root property', function () {
+        expect(actual.params.id).to.eql('bot-user-id');
+      });
+
+      it('sets the bot scope as a root property', function () {
+        expect(actual.params.scope).to.eql('bot-scope-1,bot-scope-2');
+      });
+
+      it('sets the bot tokentype as a root property', function () {
+        expect(actual.params.token_type).to.eql('bot');
+      });
+
+      it('sets the bot access_token as a root property', function () {
+        expect(actual.params.access_token).to.eql('bot-token');
+      });
+
+      it('sets the bot refresh_token as a root property', function () {
+        expect(actual.params.refresh_token).to.not.exist;
+      });
+    });
+
+    context('authed_user', function () {
+      it('sets the user id on the authed_user property', function () {
+        expect(actual.params.authed_user.id).to.eql('user-id');
+      });
+
+      it('does not set any other properties on the authed_user object', function () {
+        expect(Object.keys(actual.params.authed_user)).to.eql(['id']);
+      });
+    });
+
+    context('authed_bot', function () {
+      it('sets the bot id on the authed_bot property', function () {
+        expect(actual.params.authed_bot.id).to.eql('bot-user-id');
+      });
+
+      it('sets the bot scope on the authed_bot property', function () {
+        expect(actual.params.authed_bot.scope).to.eql('bot-scope-1,bot-scope-2');
+      });
+
+      it('sets the bot tokentype on the authed_bot property', function () {
+        expect(actual.params.authed_bot.token_type).to.eql('bot');
+      });
+
+      it('sets the bot access_token on the authed_bot property', function () {
+        expect(actual.params.authed_bot.access_token).to.eql('bot-token');
+      });
+
+      it('sets the bot refresh_token on the authed_bot property', function () {
+        expect(actual.params.authed_bot.refresh_token).to.not.exist;
+      });
+    });
+  });
+});

--- a/test/strategy.handleOAuthAccessTokenReponse.test.js
+++ b/test/strategy.handleOAuthAccessTokenReponse.test.js
@@ -38,7 +38,7 @@ describe('handleOAuthAccessTokenReponse', function () {
     });
   });
 
-  context('pass thru params', function () {
+  context('shared', function () {
     let property, value;
     beforeEach(function(done) {
       strategy = new Strategy(options, () => {});
@@ -100,6 +100,68 @@ describe('handleOAuthAccessTokenReponse', function () {
         });
       });
     });
+
+    context('this.profileUrl', function () {
+      context('skipUserProfile == true', function () {
+        before(function () {
+          options.skipUserProfile = true;
+        });
+
+        after(function() {
+          delete options.skipUserProfile;
+        });
+
+        it('does not change the profileUrl', function (done) {
+          strategy = new Strategy(options, () => {});
+
+          params = {
+            authed_user: { id: 'user-id' },
+            bot_user_id: 'bot-user-id',
+            scope: 'bot-scope-1,bot-scope-2',
+            access_token: 'bot-token',
+            token_type: 'bot',
+          };
+
+          accessToken = 'bot-token';
+
+          const expectedProfileUrl = strategy.profileUrl;
+
+          strategy.handleOAuthAccessTokenResponse(accessToken, refreshToken, params, function (err, _accessToken, _refreshToken, _params) {
+            expect(strategy.profileUrl).to.eql(expectedProfileUrl);
+            done();
+          });
+        });
+      });
+
+      context('custom profileUrl', function () {
+        before(function () {
+          options.profileUrl = '/custom'
+        });
+
+        after(function() {
+          delete options.profileUrl;
+        });
+
+        it('does not change the profileUrl', function (done) {
+          strategy = new Strategy(options, () => {});
+
+          params = {
+            authed_user: { id: 'user-id' },
+            bot_user_id: 'bot-user-id',
+            scope: 'bot-scope-1,bot-scope-2',
+            access_token: 'bot-token',
+            token_type: 'bot',
+          };
+
+          accessToken = 'bot-token';
+
+          strategy.handleOAuthAccessTokenResponse(accessToken, refreshToken, params, function (err, _accessToken, _refreshToken, _params) {
+            expect(strategy.profileUrl).to.eql('/custom');
+            done();
+          });
+        });
+      });
+    });
   });
 
   context('user auth', function () {
@@ -115,12 +177,22 @@ describe('handleOAuthAccessTokenReponse', function () {
         }
       };
 
+      expect(strategy.profileUrl).to.not.exist;
+
       strategy.handleOAuthAccessTokenResponse(accessToken, refreshToken, params, function (err, _accessToken, _refreshToken, _params) {
         actual.error = err;
         actual.accessToken = _accessToken;
         actual.refresToken = _refreshToken;
         actual.params = _params;
         done();
+      });
+    });
+
+    context('this.profileUrl', function () {
+      context('skipUserProfile == false && default profileUrl', function () {
+        it('uses the profile url to get user information', function () {
+          expect(strategy.profileUrl).to.eql('https://slack.com/api/users.identity');
+        });
       });
     });
 
@@ -210,12 +282,22 @@ describe('handleOAuthAccessTokenReponse', function () {
 
       accessToken = 'bot-token';
 
+      expect(strategy.profileUrl).to.not.exist;
+
       strategy.handleOAuthAccessTokenResponse(accessToken, refreshToken, params, function (err, _accessToken, _refreshToken, _params) {
         actual.error = err;
         actual.accessToken = _accessToken;
         actual.refresToken = _refreshToken;
         actual.params = _params;
         done();
+      });
+    });
+
+    context('this.profileUrl', function () {
+      context('skipUserProfile == false && default profileUrl', function () {
+        it('uses the profile url to get user information', function () {
+          expect(strategy.profileUrl).to.eql('https://slack.com/api/users.identity');
+        });
       });
     });
 
@@ -316,12 +398,22 @@ describe('handleOAuthAccessTokenReponse', function () {
 
       accessToken = 'bot-token';
 
+      expect(strategy.profileUrl).to.not.exist;
+
       strategy.handleOAuthAccessTokenResponse(accessToken, refreshToken, params, function (err, _accessToken, _refreshToken, _params) {
         actual.error = err;
         actual.accessToken = _accessToken;
         actual.refresToken = _refreshToken;
         actual.params = _params;
         done();
+      });
+    });
+
+    context('this.profileUrl', function () {
+      context('skipUserProfile == false && default profileUrl', function () {
+        it('uses the profile url to get user information', function () {
+          expect(strategy.profileUrl).to.eql('https://slack.com/api/users.info?user=bot-user-id');
+        });
       });
     });
 


### PR DESCRIPTION
A [proposed change](https://github.com/jaredhanson/passport-oauth2/pull/174) to add a hook that would allow this strategy to reformat the OAuth2 Token Response before sending it forward to the `passport-oauth2` callback received some reasonable (though unfortunate) [push back](https://github.com/jaredhanson/passport-oauth2/pull/174#issuecomment-1555930120).

I took the advice in the push back, though probably the wrong part, and chose to not implement a solution that created a "maintenance burden".  This new pr [monkey patches](https://github.com/advisr-io/passport-slack-oauth2/blob/handle-user-tokens-and-bot-tokens-take-two/lib/strategy.js#L81) [node-oauth](https://github.com/ciaranj/node-oauth)'s [OAuth2.getOAuthAccessToken](https://github.com/ciaranj/node-oauth/blob/master/lib/oauth2.js#L182) method to reformat the OAuth2 Token Response before sending it forward to the `passport-oauth2` callback.

This change introduces the method [getOAuthAccessTokenAndHandleResponse](https://github.com/advisr-io/passport-slack-oauth2/blob/handle-user-tokens-and-bot-tokens-take-two/lib/strategy.js#L157) which wraps `this._oauth2.getOAuthAccessToken` and reformats the response before sending it forward to the callback.

---

Original Summary for PR #13

Please see https://github.com/jaredhanson/passport-oauth2/pull/174 AND https://github.com/nmaves/passport-slack-oauth2/issues/9

Slack's OAuth2 **v2** implementation overloads the OAuthTokenResponse json payload to return multiple tokens.  The root of the json object is for `bot` tokens & user tokens exist in a property called `authed_user`. 

Passport is designed to authenticate Users. When passport attempts to use the root level accessToken, it either does not exist (no bot scopes provided in authorization request) or is a bot token. 

This change leverages a new hook in the passport-oauth2 library to reformat the OAuthTokenResponse payload to set the correct `accessToken`, `refreshToken`, and `params` for the following scenarios:

- user
- user and bot
- bot

---

The profileUrl is no longer defaulted during configuration. When the profile is not being skipped & a custom profileUrl was not provided, the profileUrl is set during `handleOAuthAccessTokenResponse` depending on which token is the root of the params object. 

---

if this is merged, the README should be updated to emphasize the verify callback that accepts the params object from the OAuthTokenResponse request. 

the params object will be reformatted to:

`user_scope` - user only
```javascript
{
  id: 'user-id',
  scope: 'user-scope-1,user-scope-2',
  token_type: 'user',
  access_token: 'user-access-token',
  refresh_token: undefined,
  authed_user: {
    id: 'user-id',
    scope: 'user-scope-1,user-scope-2',
    access_token: 'user-access-token',
    token_type: 'user'
  },
  authed_bot: {}
}
```

`scope` - bot only
```javascript
{
  id: 'bot-user-id',
  scope: 'bot-scope-1,bot-scope-2',
  token_type: 'bot',
  access_token: 'bot-token',
  refresh_token: undefined,
  authed_user: { id: 'user-id' },
  authed_bot: {
    id: 'bot-user-id',
    scope: 'bot-scope-1,bot-scope-2',
    token_type: 'bot',
    access_token: 'bot-token',
    refresh_token: undefined
  }
}
```


`scope` & `user_scope` - bot & user
```javascript
{
  id: 'user-id',
  scope: 'user-scope-1,user-scope-2',
  token_type: 'user',
  access_token: 'user-access-token',
  refresh_token: undefined,
  authed_user: {
    id: 'user-id',
    scope: 'user-scope-1,user-scope-2',
    access_token: 'user-access-token',
    token_type: 'user'
  },
  authed_bot: {
    id: 'bot-user-id',
    scope: 'bot-scope-1,bot-scope-2',
    token_type: 'bot',
    access_token: 'bot-token',
    refresh_token: undefined
  }
}
```